### PR TITLE
fix(index): take only first x emoji's set by the script

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,8 @@ const checkResponses = async () => {
   });
 
   const max = message.reactions
+    // Take only the first x emoji's
+    .slice(0, Object.keys(timeMap).length)
     .map((value) => ({ value, sort: Math.random() }))
     .sort((a, b) => a.sort - b.sort)
     .map(({ value }) => value)


### PR DESCRIPTION
Het probleem is dat die alle emoji's gaat bekijken. Enkel de eerst x aantal die door de bot aangeduid zijn, moeten in acht genomen worden. Om het dynamischer te houden, zijn het aantal in acht te nemen emoji's gelijk aan het aantal emoji's die op de post gezet gaan worden.